### PR TITLE
Include more files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE.txt
+include Demo*.py
+include Demo*.m
+include OpticalFlow_Python_vs_Matlab.py
+include mypy.ini
+
+graft tests


### PR DESCRIPTION
Include additional files in sdists.  In particular include the license text, which the license requires.  Also include tests and demos.