### PR TITLE
Fix missing tests files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include LICENSE.txt
-recursive-include tests *.py *.png
+
+include mypy.ini
+include pytest.ini
+graft tests


### PR DESCRIPTION
This approach will include all files no matter what the extension.